### PR TITLE
docs: remove outdated highlight.js references, update to Shiki

### DIFF
--- a/packages/react-code-view/README.md
+++ b/packages/react-code-view/README.md
@@ -8,7 +8,7 @@ A React component library for rendering code with live preview and syntax highli
 ## Features
 
 - 🎨 **Live Preview** - Execute and preview React code in real-time
-- ✨ **Syntax Highlighting** - Powered by highlight.js
+- ✨ **Syntax Highlighting** - Powered by Shiki
 - ✏️ **Editable Code** - Built-in code editor with optional CodeMirror support
 - 📝 **Markdown Support** - Render markdown with code blocks
 - 🔌 **Universal Plugin** - Works with Webpack, Vite, Rollup, esbuild, and Rspack
@@ -33,9 +33,6 @@ yarn add react-code-view
 ```tsx
 import CodeView from 'react-code-view';
 import 'react-code-view/styles';
-
-// Optional: import highlight.js theme
-import 'highlight.js/styles/atom-one-dark.css';
 
 function App() {
   const code = `

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -16,9 +16,6 @@ npm install @react-code-view/react @react-code-view/core
 import { CodeView } from '@react-code-view/react';
 import '@react-code-view/react/styles/index.css';
 
-// Optional: import highlight theme
-import 'highlight.js/styles/atom-one-dark.css';
-
 function App() {
   const code = `
 <Button color="primary">

--- a/packages/unplugin/README.md
+++ b/packages/unplugin/README.md
@@ -141,7 +141,7 @@ interface PluginOptions {
    */
   rendererOptions?: {
     languages?: string[];
-    // ... highlight.js options
+    // ... Shiki options
   };
 }
 ```


### PR DESCRIPTION
- Replace 'Powered by highlight.js' with 'Powered by Shiki' in feature list
- Remove unnecessary highlight.js CSS import examples
- Update rendererOptions comment to reference Shiki instead of highlight.js
- Project has been using Shiki since v3.0.0, documentation now reflects this